### PR TITLE
[Feature] Program Escrow

### DIFF
--- a/build/main.aleo
+++ b/build/main.aleo
@@ -1,8 +1,131 @@
 import credits.aleo;
 program lodive.aleo;
 
-function main:
-    input r0 as u32.public;
+record Tickets:
+    owner as address.private;
+    event_id as field.private;
+    num_tickets as u32.private;
+    ticket_price as u64.private;
+
+struct Venue:
+    id as field;
+    commission_rate as u8;
+    venue_owner as field;
+
+struct Event:
+    id as field;
+    venue_id as field;
+    ticket_supply as u32;
+    initial_ticket_supply as u32;
+    ticket_price as u64;
+    redeemed_tickets as u32;
+    is_ended as boolean;
+    is_refunded as boolean;
+    event_owner as field;
+
+mapping venues:
+    key as field.public;
+    value as Venue.public;
+
+mapping events:
+    key as field.public;
+    value as Event.public;
+
+mapping payouts:
+    key as field.public;
+    value as u64.public;
+
+function register_venue:
+    input r0 as field.private;
+    input r1 as u8.private;
+    hash.bhp1024 self.caller into r2 as field;
+    cast r0 r1 r2 into r3 as Venue;
+    async register_venue r3 into r4;
+    output r4 as lodive.aleo/register_venue.future;
+
+finalize register_venue:
+    input r0 as Venue.public;
+    contains venues[r0.id] into r1;
+    not r1 into r2;
+    assert.eq r2 true;
+    set r0 into venues[r0.id];
+    contains payouts[r0.venue_owner] into r3;
+    not r3 into r4;
+    branch.eq r4 false to end_then_0_0;
+    set 0u64 into payouts[r0.venue_owner];
+    branch.eq true true to end_otherwise_0_1;
+    position end_then_0_0;
+    position end_otherwise_0_1;
+
+function register_event:
+    input r0 as field.private;
     input r1 as u32.private;
-    add r0 r1 into r2;
-    output r2 as u32.private;
+    input r2 as u64.private;
+    input r3 as field.private;
+    input r4 as field.private;
+    cast r0 r3 r1 r1 r2 0u32 false false r4 into r5 as Event;
+    hash.bhp1024 self.caller into r6 as field;
+    async register_event r5 r6 into r7;
+    output r7 as lodive.aleo/register_event.future;
+
+finalize register_event:
+    input r0 as Event.public;
+    input r1 as field.public;
+    contains events[r0.id] into r2;
+    not r2 into r3;
+    assert.eq r3 true;
+    set r0 into events[r0.id];
+    get venues[r0.venue_id] into r4;
+    assert.eq r1 r4.venue_owner;
+    contains payouts[r0.event_owner] into r5;
+    not r5 into r6;
+    branch.eq r6 false to end_then_0_2;
+    set 0u64 into payouts[r0.event_owner];
+    branch.eq true true to end_otherwise_0_3;
+    position end_then_0_2;
+    position end_otherwise_0_3;
+
+function buy_tickets:
+    input r0 as field.private;
+    input r1 as u32.private;
+    input r2 as u64.private;
+    input r3 as credits.aleo/credits.record;
+    cast r1 into r4 as u64;
+    mul r2 r4 into r5;
+    call credits.aleo/transfer_private_to_public r3 lodive.aleo r5 into r6 r7;
+    cast self.caller r0 r1 r2 into r8 as Tickets.record;
+    hash.bhp1024 self.caller into r9 as field;
+    async buy_tickets r0 r1 r2 r9 r7 into r10;
+    output r8 as Tickets.record;
+    output r6 as credits.aleo/credits.record;
+    output r10 as lodive.aleo/buy_tickets.future;
+
+finalize buy_tickets:
+    input r0 as field.public;
+    input r1 as u32.public;
+    input r2 as u64.public;
+    input r3 as field.public;
+    input r4 as credits.aleo/transfer_private_to_public.future;
+    get events[r0] into r5;
+    is.eq r5.ticket_price r2 into r6;
+    assert.eq r6 true;
+    gte r5.ticket_supply r1 into r7;
+    assert.eq r7 true;
+    not r5.is_ended into r8;
+    assert.eq r8 true;
+    not r5.is_refunded into r9;
+    assert.eq r9 true;
+    hash.bhp1024 r5.event_owner into r10 as field;
+    assert.neq r3 r10;
+    get venues[r5.venue_id] into r11;
+    hash.bhp1024 r11.venue_owner into r12 as field;
+    assert.eq r3 r12;
+    sub r5.ticket_supply r1 into r13;
+    cast r5.id r5.venue_id r13 r5.initial_ticket_supply r5.ticket_price r5.redeemed_tickets r5.is_ended r5.is_refunded r5.event_owner into r14 as Event;
+    set r14 into events[r0];
+    await r4;
+    get.or_use payouts[r5.id] 0u64 into r15;
+    cast r1 into r16 as u64;
+    mul r2 r16 into r17;
+    add r15 r17 into r18;
+    set r18 into payouts[r5.event_owner];

--- a/build/main.aleo
+++ b/build/main.aleo
@@ -23,6 +23,10 @@ struct Event:
     is_refunded as boolean;
     event_owner as field;
 
+struct TicketHolder:
+    event_id as field;
+    owner_hash as field;
+
 mapping venues:
     key as field.public;
     value as Venue.public;
@@ -34,6 +38,10 @@ mapping events:
 mapping payouts:
     key as field.public;
     value as u64.public;
+
+mapping tickets_sold:
+    key as TicketHolder.public;
+    value as u32.public;
 
 function register_venue:
     input r0 as field.private;
@@ -129,3 +137,7 @@ finalize buy_tickets:
     mul r2 r16 into r17;
     add r15 r17 into r18;
     set r18 into payouts[r5.event_owner];
+    cast r0 r3 into r19 as TicketHolder;
+    get.or_use tickets_sold[r19] 0u32 into r20;
+    add r20 r1 into r21;
+    set r21 into tickets_sold[r19];

--- a/src/main.leo
+++ b/src/main.leo
@@ -27,6 +27,8 @@ program lodive.aleo {
         venue_id: field,
         // Number of tickets available for the event.
         ticket_supply: u32,
+        // Number of tickets initially available for the event.
+        initial_ticket_supply: u32,
         // Price per ticket in microcredits.
         ticket_price: u64,
         // Number of sold tickets which have been redeemed.
@@ -41,7 +43,7 @@ program lodive.aleo {
 
     // Mapping of events by id.
     mapping events: field => Event;
-    // Mapping of event owner address hashes to the sums they are owed.
+    // Mapping of event ids to the sums the event owners are owed.
     mapping payouts: field => u64;
 
 
@@ -94,6 +96,7 @@ program lodive.aleo {
         let event: Event = Event {
             id,
             ticket_supply,
+            initial_ticket_supply: ticket_supply,
             ticket_price,
             redeemed_tickets: 0u32,
             is_ended: false,
@@ -120,5 +123,84 @@ program lodive.aleo {
         if !payouts.contains(event.event_owner) {
             payouts.set(event.event_owner, 0u64);
         }
+    }
+
+    /////////////////////////////////
+    /// Buy tickets for an event. ///
+    /////////////////////////////////
+    async transition buy_tickets(
+        event_id: field,
+        num_tickets: u32,
+        ticket_price: u64,
+        buyer_record: credits.aleo/credits,
+    ) -> (Tickets, credits.aleo/credits, Future) {
+        let (change, transfer_fut): (credits.aleo/credits, Future) = credits.aleo/transfer_private_to_public(
+            buyer_record,
+            lodive.aleo,
+            ticket_price * num_tickets as u64,
+        );
+
+        let tickets: Tickets = Tickets {
+            owner: self.caller,
+            event_id,
+            num_tickets,
+            ticket_price,
+        };
+
+        return (tickets, change, finalize_buy_tickets(
+            event_id,
+            num_tickets,
+            ticket_price,
+            BHP1024::hash_to_field(self.caller),
+            transfer_fut,
+        ));
+    }
+
+    async function finalize_buy_tickets(
+        event_id: field,
+        num_tickets: u32,
+        ticket_price: u64,
+        caller_hash: field,
+        transfer_fut: Future,
+    ) {
+        let event: Event = events.get(event_id);
+        // Ensure the ticket price is correct.
+        assert(event.ticket_price.eq(ticket_price));
+        // Ensure the event has enough tickets remaining.
+        assert(event.ticket_supply.gte(num_tickets));
+
+        // Ensure the event has not already ended.
+        assert(!event.is_ended);
+        // Ensure the event has not already been refunded.
+        assert(!event.is_refunded);
+
+        // Ensure the buyer is not the event owner.
+        assert_neq(caller_hash, BHP1024::hash_to_field(event.event_owner));
+
+        let venue: Venue = venues.get(event.venue_id);
+        // Esnure the buyer is not the venue owner.
+        assert_eq(caller_hash, BHP1024::hash_to_field(venue.venue_owner));
+
+        // Decrement the ticket supply.
+        let new_ticket_supply: u32 = event.ticket_supply - num_tickets;
+
+        events.set(event_id, Event {
+            id: event.id,
+            venue_id: event.venue_id,
+            ticket_supply: new_ticket_supply,
+            initial_ticket_supply: event.initial_ticket_supply,
+            ticket_price: event.ticket_price,
+            redeemed_tickets: event.redeemed_tickets,
+            is_ended: event.is_ended,
+            is_refunded: event.is_refunded,
+            event_owner: event.event_owner,
+        });
+
+        // Await the transfer future.
+        transfer_fut.await();
+
+        // Add the amount owed to the event owner.
+        let new_payout: u64 = payouts.get_or_use(event.id, 0u64) + (ticket_price * num_tickets as u64);
+        payouts.set(event.event_owner, new_payout);
     }
 }

--- a/src/main.leo
+++ b/src/main.leo
@@ -52,10 +52,24 @@ program lodive.aleo {
     //////////////////////////////////
     record Tickets {
         owner: address,
+        // Unique identifier for the event.
         event_id: field,
+        // Number of tickets purchased.
         num_tickets: u32,
+        // Price per ticket in microcredits.
         ticket_price: u64,
     }
+
+    // Struct representing a ticket holder for an event. To be hashed as the key for the `tickets_sold` mapping.
+    struct TicketHolder {
+        // Unique identifier for the event.
+        event_id: field,
+        // Hash of the address of the ticket holder.
+        owner_hash: field,
+    }
+
+    // Mapping of TicketHolder to the number of tickets the records hold.
+    mapping tickets_sold: TicketHolder => u32;
 
     ///////////////////////////
     /// Initialize a venue. ///
@@ -202,5 +216,14 @@ program lodive.aleo {
         // Add the amount owed to the event owner.
         let new_payout: u64 = payouts.get_or_use(event.id, 0u64) + (ticket_price * num_tickets as u64);
         payouts.set(event.event_owner, new_payout);
+
+        let ticket_holder: TicketHolder = TicketHolder{
+            event_id,
+            owner_hash: caller_hash
+        };
+
+        // Update the number of tickets sold to for the event.
+        let prev_tickets_sold: u32 = tickets_sold.get_or_use(ticket_holder, 0u32);
+        tickets_sold.set(ticket_holder, prev_tickets_sold + num_tickets);
     }
 }


### PR DESCRIPTION
Adds `buy_tickets` function which transfers private to public from a buyers record to the program escrow. This also adds to the `tickets_sold` mapping which tracks tickets that have not been redeemed and are eligible for refund.